### PR TITLE
chore(package.json): add bin target

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "lint:server:eslint": "eslint pkg/server",
     "lint:server:prettier": "prettier --check pkg/server"
   },
+  "bin": {
+    "kulala-ls": "pkg/server/cli.cjs"
+  },
   "workspaces": [
     "pkg/*"
   ],


### PR DESCRIPTION
This is useful for packaging `kulala-ls` for use with NVim or VSCode. This way,
`npm i -g`, `npm pack`, `npx`, `nix` and other package managers can pick up how
to put the cjs file in the $PATH.
